### PR TITLE
Docs: defer roxygen to alpha; # comments only for now

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ without the `methylCIPHER-meta` repo or any downloads. Only regenerating the cat
 install.packages("pak")
 pak::local_install_deps(dependencies = TRUE)  # reads DESCRIPTION incl. GitHub-only Remotes
 devtools::load_all()      # attach the package for interactive work
-devtools::document()      # regenerate NAMESPACE + man/ from roxygen; run after any export/doc change
+# no devtools::document() yet -- roxygen is deferred until the alpha (see invariants)
 devtools::test()          # always-on test tiers (cohort parity auto-skips if not staged)
 devtools::check()         # full R CMD check
 ```
@@ -48,8 +48,10 @@ Do not reverse these without a `dev/DECISIONS.md` entry explaining why.
   (`get_clock`, `clock_coefs`, ...), never raw nested catalog lists. No hand-written `schema.md`.
 - **No network at install / build / check / CRAN test.** Double-precision coefficients only.
 - **No commit SHA / pin as result provenance.** Correctness is proven by fixtures.
-- **`NAMESPACE` and `man/*.Rd` are generated, never hand-edited.** Edit the roxygen comments in
-  `R/*.R` and run `devtools::document()` after any change to exports or docs (roxygen2 8.0.0).
+- **No roxygen yet.** Do **not** write roxygen blocks or run `devtools::document()`. Document code
+  with short `#` comments only (see "Comments" below). Turning roxygen on is a **human-decided
+  override** tied to the alpha release -- there is no automatic trigger; do not add it on your own.
+  `NAMESPACE` and `man/*.Rd` are still hand-managed leftovers until then; do not regenerate them.
 
 ## sync.R workflow (`data-raw/sync.R`)
 
@@ -103,6 +105,8 @@ Write **plain ASCII** in every file you create or edit -- no "smart" punctuation
 
 ## Comments
 
+- Plain `#` comments are the **only** in-source documentation right now -- no roxygen (see the
+  "No roxygen yet" invariant).
 - Code comments are **short**: 1-2 sentences saying *what* the code does, not a rationale essay.
 - The *why* behind a design, and every decision or reversal, goes **only** in `dev/DECISIONS.md` --
   never as a long explanatory comment in the source.
@@ -128,7 +132,7 @@ Local-only (gitignored, not on a fresh clone): `dev/legacy/` (frozen pre-rewrite
 ## Contributing
 
 - Branch off `main` and open a PR; do not push directly to `main`.
-- Run `devtools::document()` and `devtools::test()` before pushing.
+- Run `devtools::test()` before pushing. Do **not** run `devtools::document()` (no roxygen yet).
 - Reversing or second-guessing a design? Add a dated, newest-first entry to `dev/DECISIONS.md`.
 - Keep new or edited content ASCII (see above).
 

--- a/dev/DECISIONS.md
+++ b/dev/DECISIONS.md
@@ -12,6 +12,25 @@ second-guessed; do not restate rules already stated in the migration / detail pl
 
 ---
 
+## 2026-07-21 -- no roxygen yet; plain `#` comments are the only in-source docs pre-alpha
+
+**Decision.** The package carries **no roxygen** during the rewrite. Do not author roxygen
+blocks and do not run `devtools::document()`. In-source documentation is short `#` comments
+only (the existing "Comments" rule: 1-2 sentences on *what*, not *why*).
+
+**Why.** The API surface is still moving; regenerating `NAMESPACE` / `man/*.Rd` on every change
+is churn with no reader yet, and half-written roxygen would rot against the code. `man/*.Rd` and
+the live `NAMESPACE` remain the hand-managed pre-rewrite leftovers noted below until roxygen is
+switched on.
+
+**Trigger.** Turning roxygen on is a **human-decided override** tied to the alpha release --
+there is **no** automatic condition (no version tag, no milestone gate). Claude must not enable
+it on its own initiative.
+
+**Supersedes.** The earlier CLAUDE.md guidance to "run `devtools::document()` after any
+export/doc change" and to treat `NAMESPACE` / `man/*.Rd` as roxygen-generated. Those lines were
+rewritten to the "No roxygen yet" invariant.
+
 ## 2026-07-21 -- maintainer handoff to Hung Pham; license is BSD-3 (not the anticipated GPL-2)
 
 **Decision.** Two DESCRIPTION-level facts recorded now that they are set in package metadata.
@@ -620,9 +639,9 @@ at small n, and those do not need a bespoke shipped fixture once engine units co
 **Decision.** No hand-written `schema.md`. The sysdata shape is defined by `build_index()` /
 `build_catalog()` in `data-raw/sync.R`, and the **accessor layer is the executable schema**:
 `get_clock()`, `clock_scoring_cpgs()`, `clock_norm_cpgs()`, `clock_impute()`, `clock_coefs()`,
-`clock_group_bundle()`. Their roxygen states the fields/types; a `testthat` test asserts
-`names(mc_index)` and a sample `mc_catalog` entry's structure, so a shape change breaks a test
-and forces the doc update. `calc_clocks` code consumes only accessors -- never raw
+`clock_group_bundle()`. Their `#` comments state the fields/types (roxygen deferred to alpha, per
+the 2026-07-21 entry); a `testthat` test asserts `names(mc_index)` and a sample `mc_catalog`
+entry's structure, so a shape change breaks a test and forces the comment update. `calc_clocks` code consumes only accessors -- never raw
 `entry$components[[i]]$file`. Covariate requirements are one flattened catalog field
 (`covariates_required`, computed by sync's `extract_covariates`), read once at runtime, never
 re-derived from three meta keys in the scoring path.

--- a/dev/detail-plan.md
+++ b/dev/detail-plan.md
@@ -558,9 +558,9 @@ group_metas <- metas[basename(metas) == "_group.meta.json"]
 **Schema = accessors, not a doc.** The sysdata shape is defined by `build_index()` /
 `build_catalog()`. The executable schema is the accessor layer -- `get_clock()`,
 `clock_scoring_cpgs()`, `clock_norm_cpgs()`, `clock_impute()`, `clock_coefs()`,
-`clock_group_bundle()` -- whose roxygen states fields/types and whose structural `testthat` test
-asserts `names(mc_index)` + a sample `mc_catalog` entry. A shape change breaks the test and forces
-the doc update. `calc_clocks` code consumes only accessors, never raw nested lists. No
+`clock_group_bundle()` -- documented via short `#` comments for now (roxygen deferred to alpha)
+and whose structural `testthat` test asserts `names(mc_index)` + a sample `mc_catalog` entry. A
+shape change breaks the test and forces the comment update. `calc_clocks` code consumes only accessors, never raw nested lists. No
 hand-written `schema.md` (it would drift, the class the meta repo's `meta_schema.py` exists to
 eliminate); generate one from the objects if ever needed.
 


### PR DESCRIPTION
## Summary

Adds a **"No roxygen yet"** project invariant: the package is documented with short `#` comments
only until a human-decided alpha override turns roxygen on. There is **no** automatic trigger
(no version tag, no milestone gate) -- enabling roxygen is a maintainer call.

## Changes

- **CLAUDE.md**: new "No roxygen yet" invariant; getting-started drops `devtools::document()`;
  Contributing no longer runs `document()` before pushing; Comments section notes `#` comments
  are the only in-source docs for now.
- **dev/DECISIONS.md**: dated 2026-07-21 entry recording the decision, rationale, and
  human-override trigger; supersedes the old "run document() after any doc change" guidance.
- **dev/detail-plan.md** and the older bundle-schema DECISIONS entry: accessor documentation
  wording aligned from "roxygen states fields/types" to "`#` comments (roxygen deferred to alpha)".

Docs-only; no code or behavior change.
